### PR TITLE
temporarily disable email verification

### DIFF
--- a/checkout/views.py
+++ b/checkout/views.py
@@ -10,11 +10,11 @@ from django.views.decorators.csrf import csrf_exempt
 import re
 from django.http import HttpResponse
 from django.utils.crypto import get_random_string
-from allauth.account.decorators import verified_email_required
+# from allauth.account.decorators import verified_email_required
 # Create your views here.
 
 
-@verified_email_required
+# @verified_email_required  # Disable till issue with google less secure app is resolved
 def checkout_view(request):
     form = BillingForm
     order = Order.objects.filter(user=request.user, ordered=False)[0]

--- a/medical/settings.py
+++ b/medical/settings.py
@@ -27,9 +27,11 @@ ACCOUNT_FORMS = {
     "signup": "home.forms.UserSignUp"
 }
 
-CRISPY_TEMPLATE_PACK = 'bootstrap4'
-# Application definition
+ACCOUNT_EMAIL_VERIFICATION = 'none'
 
+CRISPY_TEMPLATE_PACK = 'bootstrap4'
+
+# Application definition
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',


### PR DESCRIPTION
From time to time, I had to turn on the `less secure app access` on Google account, but now, `smtp` isn't working after turning on the access and unlocking the captcha also...
Email verification will be disabled with merging of this pull, will need to integrate another method | library | api to send mail, in case of verification as well as other use cases.