### PR TITLE
allow `POST` on checkout page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-indent_size = 2
+indent_size = 4
 indent_style = space
 insert_final_newline = true
 max_line_length = 120

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -1,4 +1,4 @@
-from django.views.decorators.http import require_safe, require_GET
+from django.views.decorators.http import require_safe
 from django.shortcuts import render
 from .forms import BillingForm
 from cart.models import CartItem, Order
@@ -16,7 +16,6 @@ from django.utils.crypto import get_random_string
 
 
 # @verified_email_required  # Disable till issue with google less secure app is resolved
-@require_safe
 def checkout_view(request):
     form = BillingForm
     order = Order.objects.filter(user=request.user, ordered=False)[0]
@@ -57,8 +56,6 @@ def payment(request, web=True):
 
 
 # Testing new stripe
-
-
 @csrf_exempt
 @require_safe
 def stripe_conf(request):


### PR DESCRIPTION
`checkout view` is currently allowing only `GET`...
https://github.com/mukeshgurpude/medstore/blob/daf102dc51775c308c6db43a2f13b588fdd7f209/checkout/views.py#L20
But it needs POST to update the billing data... That's why it should accept the POST method also
